### PR TITLE
[codex] Add configurable image provider

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,3 +1,8 @@
+IMAGE_PROVIDER=pollinations
+NEXT_PUBLIC_IMAGE_PROVIDER=pollinations
+IMAGE_MODEL=flux
+
+# Optional: only required when IMAGE_PROVIDER=together
 TOGETHER_API_KEY=
 
 S3_UPLOAD_KEY=

--- a/app/api/add-page/route.ts
+++ b/app/api/add-page/route.ts
@@ -1,34 +1,22 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import Together from "together-ai";
-import { db } from "@/lib/db";
-import { pages } from "@/lib/schema";
-import { eq } from "drizzle-orm";
 import {
   updatePage,
   createPage,
   getNextPageNumber,
   getStoryWithPagesBySlug,
-  getLastPageImage,
   deletePage,
 } from "@/lib/db-actions";
 import { freeTierRateLimit } from "@/lib/rate-limit";
 import { uploadImageToS3 } from "@/lib/s3-upload";
 import { buildComicPrompt } from "@/lib/prompt";
+import { generateComicImage } from "@/lib/image-provider";
 import {
   isContentPolicyViolation,
   getContentPolicyErrorMessage,
 } from "@/lib/utils";
 
-const NEW_MODEL = false;
-
-const IMAGE_MODEL = NEW_MODEL
-  ? "google/gemini-3-pro-image"
-  : "google/flash-image-2.5";
-
-const FIXED_DIMENSIONS = NEW_MODEL
-  ? { width: 896, height: 1200 }
-  : { width: 864, height: 1184 };
+const FIXED_DIMENSIONS = { width: 864, height: 1184 };
 
 export async function POST(request: NextRequest) {
   try {
@@ -140,11 +128,7 @@ export async function POST(request: NextRequest) {
       previousPages,
     });
 
-    const client = new Together({
-      apiKey: process.env.TOGETHER_API_KEY,
-    });
-
-    let response;
+    let generatedImageUrl: string;
     try {
       console.log("Starting image generation for ...");
       console.dir({
@@ -152,20 +136,19 @@ export async function POST(request: NextRequest) {
         referenceImages,
       });
       const startTime = Date.now();
-      response = await client.images.generate({
-        model: IMAGE_MODEL,
+      const result = await generateComicImage({
         prompt: fullPrompt,
         width: dimensions.width,
         height: dimensions.height,
-        reference_images:
-          referenceImages.length > 0 ? referenceImages : undefined,
+        referenceImages,
       });
+      generatedImageUrl = result.imageUrl;
       const endTime = Date.now();
       const durationMs = endTime - startTime;
       const durationSeconds = (durationMs / 1000).toFixed(2);
       console.log(`Image generation completed in ${durationSeconds} seconds`);
     } catch (error) {
-      console.error("Together AI API error:", error);
+      console.error("Image generation API error:", error);
 
       // Clean up DB records if generation failed due to content policy
       try {
@@ -232,16 +215,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!response.data || !response.data[0] || !response.data[0].url) {
-      return NextResponse.json(
-        { error: "No image URL in response" },
-        { status: 500 },
-      );
-    }
-
-    const imageUrl = response.data[0].url;
     const s3Key = `${story.id}/page-${page.pageNumber}-${Date.now()}.jpg`;
-    const s3ImageUrl = await uploadImageToS3(imageUrl, s3Key);
+    const s3ImageUrl = await uploadImageToS3(generatedImageUrl, s3Key);
 
     await updatePage(page.id, s3ImageUrl);
 

--- a/app/api/generate-comic/route.ts
+++ b/app/api/generate-comic/route.ts
@@ -1,5 +1,4 @@
 import { type NextRequest, NextResponse } from "next/server";
-import Together from "together-ai";
 import { auth } from "@clerk/nextjs/server";
 import {
   updatePage,
@@ -13,25 +12,15 @@ import {
   deleteStory,
 } from "@/lib/db-actions";
 import { freeTierRateLimit } from "@/lib/rate-limit";
-import { COMIC_STYLES } from "@/lib/constants";
 import { uploadImageToS3 } from "@/lib/s3-upload";
 import { buildComicPrompt } from "@/lib/prompt";
+import { generateComicImage, getImageProviderConfig } from "@/lib/image-provider";
 import {
   isContentPolicyViolation,
   getContentPolicyErrorMessage,
 } from "@/lib/utils";
 
-const NEW_MODEL = false;
-
-const IMAGE_MODEL = NEW_MODEL
-  ? "google/gemini-3-pro-image"
-  : "google/flash-image-2.5";
-
-const FIXED_DIMENSIONS = NEW_MODEL
-  ? { width: 896, height: 1200 }
-  : { width: 864, height: 1184 };
-
-const TEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct";
+const FIXED_DIMENSIONS = { width: 864, height: 1184 };
 
 export async function POST(request: NextRequest) {
   try {
@@ -61,18 +50,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Determine which API key to use
-    let finalApiKey = apiKey;
-    const isUsingFreeTier = !apiKey;
-    const usesOwnApiKey = !!apiKey;
+    const imageProvider = getImageProviderConfig();
+    const usesOwnApiKey = imageProvider.requiresApiKey && !!apiKey;
+    const isUsingFreeTier = !usesOwnApiKey;
 
-    if (isUsingFreeTier) {
-      // Use default API key for free tier
-      finalApiKey = process.env.TOGETHER_API_KEY;
-      if (!finalApiKey) {
+    if (imageProvider.requiresApiKey && isUsingFreeTier) {
+      if (!process.env.TOGETHER_API_KEY) {
         return NextResponse.json(
           {
-            error: "Server configuration error - default API key not available",
+            error: "Server configuration error - image API key not available",
           },
           { status: 500 },
         );
@@ -140,92 +126,7 @@ export async function POST(request: NextRequest) {
       previousContext,
     });
 
-    const client = new Together({ apiKey: finalApiKey });
-
-    // Generate title and description in parallel with image generation (only for new stories)
-    let titleGenerationPromise: Promise<{
-      title: string;
-      description: string;
-    }> | null = null;
-    if (!storyId) {
-      titleGenerationPromise = (async () => {
-        try {
-          const titlePrompt = `Based on this comic book prompt, generate a compelling title and description for the comic book.
-
-Prompt: "${prompt}"
-Style: ${COMIC_STYLES.find((s) => s.id === style)?.name || style}
-
-Generate:
-1. A catchy, engaging title (maximum 60 characters)
-2. A brief description (2-3 sentences, maximum 200 characters)
-
-Format your response as JSON:
-{
-  "title": "Title here",
-  "description": "Description here"
-}
-
-Only return the JSON, no other text.`;
-
-          const textResponse = await client.chat.completions.create({
-            model: TEXT_MODEL,
-            messages: [
-              {
-                role: "system",
-                content:
-                  "You are a creative assistant that generates compelling comic book titles and descriptions. Always respond with valid JSON only.",
-              },
-              {
-                role: "user",
-                content: titlePrompt,
-              },
-            ],
-            temperature: 0.8,
-            max_tokens: 300,
-          });
-
-          const content = textResponse.choices[0]?.message?.content?.trim();
-          if (!content) {
-            throw new Error("No response from text generation");
-          }
-
-          // Extract JSON from response (in case there's extra text)
-          const jsonMatch = content.match(/\{[\s\S]*\}/);
-          if (!jsonMatch) {
-            throw new Error("No JSON found in response");
-          }
-
-          const parsed = JSON.parse(jsonMatch[0]);
-          const rawTitle =
-            parsed.title?.trim() ||
-            (prompt.length > 50 ? prompt.substring(0, 50) + "..." : prompt);
-          const rawDescription = parsed.description?.trim();
-
-          // Enforce character limits
-          const title =
-            rawTitle.length > 60 ? rawTitle.substring(0, 57) + "..." : rawTitle;
-          const description =
-            rawDescription && rawDescription.length > 200
-              ? rawDescription.substring(0, 197) + "..."
-              : rawDescription;
-
-          return {
-            title,
-            description: description || undefined,
-          };
-        } catch (error) {
-          console.error("Error generating title and description:", error);
-          // Fallback to prompt-based title
-          return {
-            title:
-              prompt.length > 50 ? prompt.substring(0, 50) + "..." : prompt,
-            description: undefined,
-          };
-        }
-      })();
-    }
-
-    let response;
+    let generatedImageUrl: string;
     try {
       console.log("Starting image generation for ...");
       console.dir({
@@ -233,21 +134,21 @@ Only return the JSON, no other text.`;
         referenceImages,
       });
       const startTime = Date.now();
-      response = await client.images.generate({
-        model: IMAGE_MODEL,
+      const result = await generateComicImage({
         prompt: fullPrompt,
         width: dimensions.width,
         height: dimensions.height,
         temperature: 0.1, // Lower temperature for more consistent face matching
-        reference_images:
-          referenceImages.length > 0 ? referenceImages : undefined,
+        referenceImages,
+        apiKey: usesOwnApiKey ? apiKey : undefined,
       });
+      generatedImageUrl = result.imageUrl;
       const endTime = Date.now();
       const durationMs = endTime - startTime;
       const durationSeconds = (durationMs / 1000).toFixed(2);
       console.log(`Image generation completed in ${durationSeconds} seconds`);
     } catch (error) {
-      console.error("Together AI API error:", error);
+      console.error("Image generation API error:", error);
 
       // Clean up DB records if generation failed
       try {
@@ -285,7 +186,7 @@ Only return the JSON, no other text.`;
           return NextResponse.json(
             {
               error:
-                "Insufficient API credits. Please add credits to your Together.ai account at https://api.together.ai/settings/billing or update your API key.",
+                "Insufficient image generation API credits. Please update your image provider or API key.",
               errorType: "credit_limit",
             },
             { status: 402 },
@@ -310,28 +211,17 @@ Only return the JSON, no other text.`;
       );
     }
 
-    if (!response.data || !response.data[0] || !response.data[0].url) {
-      return NextResponse.json(
-        { error: "No image URL in response" },
-        { status: 500 },
-      );
-    }
-
-    const imageUrl = response.data[0].url;
-
     // Upload image to S3 for permanent storage
     const s3Key = `${storyId || story!.id}/page-${
       page.pageNumber
     }-${Date.now()}.jpg`;
-    const s3ImageUrl = await uploadImageToS3(imageUrl, s3Key);
+    const s3ImageUrl = await uploadImageToS3(generatedImageUrl, s3Key);
 
-    // Wait for title/description generation if it's a new story
     let generatedTitle: string | undefined;
     let generatedDescription: string | undefined;
-    if (titleGenerationPromise) {
-      const titleData = await titleGenerationPromise;
-      generatedTitle = titleData.title;
-      generatedDescription = titleData.description;
+    if (!storyId) {
+      generatedTitle = buildFallbackStoryTitle(prompt);
+      generatedDescription = buildFallbackStoryDescription(prompt);
 
       // Update story with generated title and description
       try {
@@ -399,4 +289,18 @@ Only return the JSON, no other text.`;
       { status: 500 },
     );
   }
+}
+
+function buildFallbackStoryTitle(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  return compact.length > 60 ? `${compact.substring(0, 57)}...` : compact;
+}
+
+function buildFallbackStoryDescription(prompt: string): string | undefined {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  if (!compact) {
+    return undefined;
+  }
+
+  return compact.length > 200 ? `${compact.substring(0, 197)}...` : compact;
 }

--- a/components/api-key-modal.tsx
+++ b/components/api-key-modal.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog"
-import { TOGETHER_LINK } from "@/lib/utils"
+import { IMAGE_PROVIDER_LINK } from "@/lib/utils"
 import { useApiKey } from "@/hooks/use-api-key"
 
 interface ApiKeyModalProps {
@@ -72,8 +72,8 @@ export function ApiKeyModal({ isOpen, onClose, onSubmit }: ApiKeyModalProps) {
 
           <DialogDescription className="text-center text-muted-foreground">
             {existingKey
-              ? "Update your Together API key or add a new one. You can also delete your existing key."
-              : "You've used all your weekly credits! Add your Together API key for unlimited generation."}
+              ? "Update your image provider API key or add a new one. You can also delete your existing key."
+              : "You've used all your weekly credits! Add an image provider API key for unlimited generation."}
           </DialogDescription>
         </DialogHeader>
 
@@ -100,12 +100,12 @@ export function ApiKeyModal({ isOpen, onClose, onSubmit }: ApiKeyModalProps) {
           </div>
 
           <a
-            href={TOGETHER_LINK}
+            href={IMAGE_PROVIDER_LINK}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-indigo hover:text-indigo-light flex items-center gap-1.5 transition-colors"
           >
-            Get your Together API key
+            Learn about the image provider
             <ExternalLink className="h-3.5 w-3.5" />
           </a>
 

--- a/components/landing/comic-creation-form.tsx
+++ b/components/landing/comic-creation-form.tsx
@@ -45,7 +45,9 @@ export function ComicCreationForm({
   const { isSignedIn, isLoaded } = useAuth();
   const { openSignIn } = useClerk();
   const [apiKey, setApiKey] = useApiKey();
-  const hasApiKey = !!apiKey;
+  const personalApiKeysEnabled =
+    process.env.NEXT_PUBLIC_IMAGE_PROVIDER === "together";
+  const hasApiKey = personalApiKeysEnabled && !!apiKey;
   const [previews, setPreviews] = useState<string[]>([]);
   const [showPreview, setShowPreview] = useState<number | null>(null);
   const [showStyleDropdown, setShowStyleDropdown] = useState(false);
@@ -233,7 +235,15 @@ export function ComicCreationForm({
         }
 
         if (creditsData.creditsRemaining === 0) {
-          setShowApiModal(true);
+          if (personalApiKeysEnabled) {
+            setShowApiModal(true);
+          } else {
+            toast({
+              title: "Weekly credits used",
+              description: "Please try again after your credits reset.",
+              variant: "destructive",
+            });
+          }
           clearInterval(stepInterval);
           setIsLoading(false);
           return;
@@ -504,7 +514,7 @@ export function ComicCreationForm({
             </Button>
             <div className="text-xs text-muted-foreground whitespace-nowrap">
               {hasApiKey ? (
-                <>Using your API key (~$0.01 per comic)</>
+                <>Using your image API key</>
               ) : (
                 <>{creditsRemaining !== null ? `${creditsRemaining} credit${creditsRemaining === 1 ? '' : 's'} remaining` : 'Checking credits...'}</>
               )}

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { TOGETHER_LINK } from "@/lib/utils";
+import { IMAGE_PROVIDER_LINK, IMAGE_PROVIDER_NAME } from "@/lib/utils";
 import { Github, MessageSquare } from "lucide-react";
 import Link from "next/link";
 import { FeedbackModal } from "@/components/feedback-modal";
@@ -22,14 +22,14 @@ export function Footer() {
       <footer className="h-8 border-t border-border/50 bg-background flex items-center justify-between px-6 text-[10px] text-muted-foreground select-none">
         <div className="flex items-center gap-4">
           <span>
-            Made & powered by{" "}
+            Image generation by{" "}
             <Link
-              href={TOGETHER_LINK}
+              href={IMAGE_PROVIDER_LINK}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-white transition-colors text-white"
             >
-              Together.ai
+              {IMAGE_PROVIDER_NAME}
             </Link>
           </span>
         </div>

--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { TOGETHER_LINK } from "@/lib/utils";
+import { IMAGE_PROVIDER_LINK, IMAGE_PROVIDER_NAME } from "@/lib/utils";
 
 export function LandingHero() {
   const [pagesLast24h, setPagesLast24h] = useState<number | null>(null);
@@ -31,15 +31,14 @@ export function LandingHero() {
       <div className="relative z-10">
         <div className="lg:text-left text-center">
           <a
-            href={TOGETHER_LINK}
+            href={IMAGE_PROVIDER_LINK}
             target="_blank"
             rel="noopener noreferrer"
             className="flex justify-center items-center gap-1 px-2.5 py-1 rounded-full border border-border glass-panel mb-4 sm:mb-6 w-fit"
           >
             <span className="text-[10px] font-medium text-muted-foreground tracking-[-0.015em]">
-              Powered by
+              Image generation by {IMAGE_PROVIDER_NAME}
             </span>
-            <img src="/poweredby.png" className="h-[18px]"/>
           </a>
 
           <h1 className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl text-foreground uppercase mb-4 sm:mb-5 tracking-wide font-heading font-semibold leading-tight sm:leading-[5.2rem]">

--- a/lib/image-provider.ts
+++ b/lib/image-provider.ts
@@ -1,0 +1,157 @@
+import type { ImageGenerateParams } from "together-ai/resources/images";
+
+const DEFAULT_PROVIDER = "pollinations";
+const DEFAULT_POLLINATIONS_BASE_URL = "https://image.pollinations.ai";
+const DEFAULT_POLLINATIONS_MODEL = "flux";
+const POLLINATIONS_MAX_PROMPT_LENGTH = 1800;
+
+type ImageProviderName = "pollinations" | "together";
+
+export interface ImageProviderConfig {
+  provider: ImageProviderName;
+  requiresApiKey: boolean;
+}
+
+export interface GenerateComicImageOptions {
+  prompt: string;
+  width: number;
+  height: number;
+  referenceImages?: string[];
+  apiKey?: string;
+  temperature?: number;
+}
+
+export interface GenerateComicImageResult {
+  imageUrl: string;
+}
+
+export function getImageProviderConfig(
+  env: Record<string, string | undefined> = process.env,
+): ImageProviderConfig {
+  const provider = (env.IMAGE_PROVIDER || DEFAULT_PROVIDER).toLowerCase();
+
+  if (provider === "together") {
+    return {
+      provider: "together",
+      requiresApiKey: true,
+    };
+  }
+
+  return {
+    provider: "pollinations",
+    requiresApiKey: false,
+  };
+}
+
+export function buildPollinationsImageUrl({
+  prompt,
+  width,
+  height,
+  seed,
+  model = process.env.IMAGE_MODEL || DEFAULT_POLLINATIONS_MODEL,
+  baseUrl = process.env.IMAGE_API_URL || DEFAULT_POLLINATIONS_BASE_URL,
+}: {
+  prompt: string;
+  width: number;
+  height: number;
+  seed?: number;
+  model?: string;
+  baseUrl?: string;
+}): string {
+  const compactPrompt = compactPromptForUrl(prompt);
+  const url = new URL(`/prompt/${encodeURIComponent(compactPrompt)}`, baseUrl);
+  url.searchParams.set("width", String(width));
+  url.searchParams.set("height", String(height));
+  url.searchParams.set("nologo", "true");
+
+  if (model) {
+    url.searchParams.set("model", model);
+  }
+
+  if (seed !== undefined) {
+    url.searchParams.set("seed", String(seed));
+  }
+
+  return url.toString();
+}
+
+export async function generateComicImage({
+  prompt,
+  width,
+  height,
+  referenceImages = [],
+  apiKey,
+  temperature,
+}: GenerateComicImageOptions): Promise<GenerateComicImageResult> {
+  const config = getImageProviderConfig();
+
+  if (config.provider === "together") {
+    return generateTogetherImage({
+      prompt,
+      width,
+      height,
+      referenceImages,
+      apiKey: apiKey || process.env.TOGETHER_API_KEY,
+      temperature,
+    });
+  }
+
+  return {
+    imageUrl: buildPollinationsImageUrl({
+      prompt,
+      width,
+      height,
+      seed: Math.floor(Math.random() * 1_000_000_000),
+    }),
+  };
+}
+
+function compactPromptForUrl(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  if (compact.length <= POLLINATIONS_MAX_PROMPT_LENGTH) {
+    return compact;
+  }
+
+  return compact.slice(0, POLLINATIONS_MAX_PROMPT_LENGTH);
+}
+
+async function generateTogetherImage({
+  prompt,
+  width,
+  height,
+  referenceImages,
+  apiKey,
+  temperature,
+}: GenerateComicImageOptions): Promise<GenerateComicImageResult> {
+  if (!apiKey) {
+    throw new Error("TOGETHER_API_KEY is required when IMAGE_PROVIDER=together");
+  }
+
+  const Together = (await import("together-ai")).default;
+  const client = new Together({ apiKey });
+  const model =
+    process.env.IMAGE_MODEL ||
+    process.env.TOGETHER_IMAGE_MODEL ||
+    "google/flash-image-2.5";
+
+  const params: ImageGenerateParams = {
+    model,
+    prompt,
+    width,
+    height,
+    temperature,
+  };
+
+  if (referenceImages.length > 0) {
+    params.reference_images = referenceImages;
+  }
+
+  const response = await client.images.generate(params);
+  const imageUrl = response.data?.[0]?.url;
+
+  if (!imageUrl) {
+    throw new Error("No image URL in response");
+  }
+
+  return { imageUrl };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,8 +5,8 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const TOGETHER_LINK =
-  "https://togetherai.link/?utm_source=make-comics&utm_medium=referral&utm_campaign=example-app";
+export const IMAGE_PROVIDER_LINK = "https://pollinations.ai/";
+export const IMAGE_PROVIDER_NAME = "Pollinations";
 
 export function isContentPolicyViolation(errorMessage: string): boolean {
   return (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-v0-project",
+  "name": "make-comics",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/test/image-provider.test.mjs
+++ b/test/image-provider.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildPollinationsImageUrl, getImageProviderConfig } from "../lib/image-provider.ts";
+
+test("pollinations config does not require an API key", () => {
+  const config = getImageProviderConfig({
+    IMAGE_PROVIDER: "pollinations",
+  });
+
+  assert.equal(config.provider, "pollinations");
+  assert.equal(config.requiresApiKey, false);
+});
+
+test("builds a pollinations image URL with encoded prompt and comic dimensions", () => {
+  const url = new URL(
+    buildPollinationsImageUrl({
+      prompt: "a noir detective in rain",
+      width: 864,
+      height: 1184,
+      seed: 123,
+    }),
+  );
+
+  assert.equal(url.origin, "https://image.pollinations.ai");
+  assert.equal(url.pathname, "/prompt/a%20noir%20detective%20in%20rain");
+  assert.equal(url.searchParams.get("width"), "864");
+  assert.equal(url.searchParams.get("height"), "1184");
+  assert.equal(url.searchParams.get("seed"), "123");
+  assert.equal(url.searchParams.get("nologo"), "true");
+});


### PR DESCRIPTION
## Summary

- Add a configurable image provider layer with Pollinations as the default provider.
- Keep Together AI available behind `IMAGE_PROVIDER=together` for deployments that still want it.
- Update generation routes and user-facing provider copy so the app no longer requires `TOGETHER_API_KEY` by default.
- Add a small Node test covering Pollinations URL/config behavior.

## Validation

- `node --experimental-strip-types --test test/image-provider.test.mjs`
- `pnpm build` with placeholder deployment environment variables

## Notes

Pollinations does not support the same reference-image consistency behavior as Together, so reference images are ignored by the default provider and retained for providers that support them.